### PR TITLE
[FEAT] parts_pipeline RDS 적재 로직 개선

### DIFF
--- a/airflow/dags/lib/rds_loader.py
+++ b/airflow/dags/lib/rds_loader.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import csv
 import io
+import re
 from typing import List
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine
 
 from lib.common import split_s3_uri
 from lib.s3_metrics import list_keys
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def normalize_sqlalchemy_uri(uri: str) -> str:
@@ -40,27 +43,115 @@ def load_summary_rows_from_s3(s3, summary_prefix: str, effective_ds: str) -> Lis
     return rows
 
 
+def _normalize_table_identifier(table: str) -> str:
+    if table is None:
+        raise ValueError("Invalid table name: None")
+
+    normalized = table.strip()
+    if not normalized:
+        raise ValueError("Invalid table name: empty")
+
+    parts = [part.strip() for part in normalized.split(".")]
+    if len(parts) not in (1, 2):
+        raise ValueError(f"Invalid table name: {table}")
+
+    cleaned_parts = []
+    for part in parts:
+        # Allow optional quoting in Variable values, e.g. "test"."parts_master".
+        if len(part) >= 2 and part.startswith('"') and part.endswith('"'):
+            part = part[1:-1]
+        if not _IDENTIFIER_RE.match(part):
+            raise ValueError(f"Invalid table identifier: {table}")
+        cleaned_parts.append(part)
+
+    if len(cleaned_parts) == 2:
+        return f'"{cleaned_parts[0]}"."{cleaned_parts[1]}"'
+    return f'"{cleaned_parts[0]}"'
+
+
+def _copy_rows_to_stage(cursor, stage_table: str, rows: List[dict]) -> None:
+    buf = io.StringIO()
+    writer = csv.writer(buf, lineterminator="\n")
+    for row in rows:
+        writer.writerow(
+            [
+                row["part_official_name"],
+                row["extracted_at"],
+                row["min_price"],
+                row["max_price"],
+                row["car_type"],
+            ]
+        )
+    buf.seek(0)
+    cursor.copy_expert(
+        (
+            f"COPY {stage_table} "
+            "(part_official_name, extracted_at, min_price, max_price, car_type) "
+            "FROM STDIN WITH (FORMAT csv)"
+        ),
+        buf,
+    )
+
+
+def _dedupe_rows(rows: List[dict]) -> List[dict]:
+    latest_by_key = {}
+    for row in rows:
+        key = (row["part_official_name"], row["car_type"], row["extracted_at"])
+        latest_by_key[key] = row
+    return list(latest_by_key.values())
+
+
 def upsert_rows_to_rds(engine, table: str, effective_ds: str, rows: List[dict]) -> None:
-    with engine.begin() as conn:
-        conn.execute(
-            text(
+    target_table = _normalize_table_identifier(table)
+    deduped_rows = _dedupe_rows(rows)
+
+    raw_conn = engine.raw_connection()
+    try:
+        with raw_conn.cursor() as cursor:
+            cursor.execute(
                 f"""
-                DELETE FROM {table}
-                WHERE extracted_at < (CAST(:dt AS DATE) - INTERVAL '30 day')
+                DELETE FROM {target_table}
+                WHERE extracted_at < (CAST(%s AS DATE) - INTERVAL '1 month')
+                """,
+                (effective_ds,),
+            )
+
+            cursor.execute(
                 """
-            ),
-            {"dt": effective_ds},
-        )
-        conn.execute(
-            text(
+                CREATE TEMP TABLE _parts_master_stage (
+                    part_official_name TEXT NOT NULL,
+                    extracted_at DATE NOT NULL,
+                    min_price INT,
+                    max_price INT,
+                    car_type TEXT NOT NULL
+                ) ON COMMIT DROP
+                """
+            )
+            _copy_rows_to_stage(cursor, "_parts_master_stage", deduped_rows)
+            cursor.execute(
                 f"""
-                INSERT INTO {table}
+                INSERT INTO {target_table}
                 (part_official_name, extracted_at, min_price, max_price, car_type)
-                VALUES (:part_official_name, :extracted_at, :min_price, :max_price, :car_type)
+                SELECT
+                    part_official_name,
+                    extracted_at,
+                    min_price,
+                    max_price,
+                    car_type
+                FROM _parts_master_stage
+                ON CONFLICT (part_official_name, car_type, extracted_at)
+                DO UPDATE
+                SET
+                    min_price = EXCLUDED.min_price,
+                    max_price = EXCLUDED.max_price
                 """
-            ),
-            rows,
-        )
+            )
+        raw_conn.commit()
+    except Exception:
+        raw_conn.rollback()
+        raise
+    finally:
+        raw_conn.close()
 
 
 def build_engine_from_airflow_uri(uri: str):


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
COPY 벌크로드 적용 및 보존 정책 정비

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #54 

## ⏳ 작업 내용
<!-- 어떤 기능을 추가/수정/삭제했는지 요약해 주세요. 
핵심적인 구현 포인트, 구조 설계 변경 내용 등 명확히 설명  
-->
- load_to_rds의 Postgres 적재를 INSERT executemany에서 COPY + staging upsert로 바꿈
- RDS_TABLE 식별자 검증을 강화해 런타임 에러 가능성을 줄인다.
- 보존 정책을 “30일”이 아닌 “1개월” 기준으로 정리


## 📸 스크린샷
<!-- UI, Swagger 응답, DB 결과 등 시각적인 비교 자료가 있다면 첨부해주세요.  -->
- 

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 보안그룹 5432 열어주기

## 📌 참고 자료
<!-- 참고한 공식 문서, 블로그, StackOverflow 링크 등 있다면 남겨주세요. -->
- 